### PR TITLE
Fix English description wording

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,7 +8,7 @@
     "description": "Extension short name"
   },
   "description": {
-    "message": "Easy delete the account that you don't want more.",
+    "message": "Easily delete accounts you no longer want.",
     "description": "Extension description"
   }
 }


### PR DESCRIPTION
## Summary
- update extension description in English locale file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840546fcf448330918bc88a1db0c051