### PR TITLE
Fix subdomain stripping logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -69,7 +69,9 @@ function getHostname(url, optsStrict = false) {
 
   let hostname = urlObj.hostname;
   subdomains.forEach((sub) => {
-    hostname = hostname.replace(`${sub}.`, "");
+    if (hostname.startsWith(sub + ".")) {
+      hostname = hostname.slice(sub.length + 1);
+    }
   });
 
   return hostname;


### PR DESCRIPTION
## Summary
- ensure `getHostname` only removes subdomains that appear as a prefix

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684055e203b88330a1f5cda4c1bd9890